### PR TITLE
Update to 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.9-SNAPSHOT'
+    id 'fabric-loom' version '0.10.+'
     id 'maven-publish'
 }
 
@@ -43,7 +43,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 16
+def targetJavaVersion = 17
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17
-yarn_mappings=1.17+build.13
-loader_version=0.11.7
+minecraft_version=1.18
+yarn_mappings=1.18+build.1
+loader_version=0.12.8
 # Mod Properties
-mod_version=1.0+1.17
+mod_version=1.0+1.18
 maven_group=com.thegameratort.titlefixer
 archives_base_name=titlefixer
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.40.1+1.17
-cloth_config_version=5.0.38
-modmenu_version=2.0.13
+fabric_version=0.44.0+1.18
+cloth_config_version=6.0.45
+modmenu_version=3.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.11.7",
-    "minecraft": ">=1.17-",
+    "minecraft": ">=1.17.1",
     "cloth-config2": ">=5.0.38"
   }
 }

--- a/src/main/resources/titlefixer.mixins.json
+++ b/src/main/resources/titlefixer.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.thegameratort.titlefixer.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [


### PR DESCRIPTION
Including all dependencies, no code changed since everything works (I tested it).

(If you would like to, create a 1.18 branch I can point the PR to so no other versions get overwritten since it does not function anymore with <=1.17.x due to another java update and minecraft just refuses to launch with a higher java version set as the required version)